### PR TITLE
Rutas para all matches

### DIFF
--- a/api/src/routes/tournaments.ts
+++ b/api/src/routes/tournaments.ts
@@ -100,6 +100,40 @@ router.get(
     }
   }
 );
+router.get(
+  "/:id/allmatches",
+  async (req: express.Request, res: express.Response) => {
+    const { id } = req.params;
+    console.log("entró");
+    try {
+      const result = await prisma.matches.findMany({
+        where: {
+          tournament_id: id,
+        },
+        include: {
+          team_a: {
+            select: {
+              name: true,
+              shield_url: true,
+              id: true,
+            },
+          },
+          team_b: {
+            select: {
+              name: true,
+              shield_url: true,
+              id: true,
+            },
+          },
+        },
+      });
+
+      res.status(200).send(result);
+    } catch (error) {
+      res.status(400).send(error);
+    }
+  }
+);
 
 router.get("/:id", async (req: express.Request, res: express.Response) => {
   const { id } = req.params;

--- a/client/src/components/TeamAdd.tsx
+++ b/client/src/components/TeamAdd.tsx
@@ -246,7 +246,7 @@ export default function TeamAdd({
             </FormControl>
           </Flex>
           {checkError && (
-            <Flex mt="4" alignItems="center">
+            <Flex mt="4" alignItems="center" justifyContent="center">
               <Icon as={FaExclamationCircle} color="red.500" mr="2" />
               <Text as="span" color="red.500" fontWeight="500" fontSize="20px">
                 {checkError}

--- a/client/src/redux/slices/tournament.ts
+++ b/client/src/redux/slices/tournament.ts
@@ -5,6 +5,7 @@ import {
   fetchTournamentDetail,
   fetchTournamentMatches,
   fetchTournamentRanking,
+  fetchTournamentAllMatches,
 } from "./tournamentThunk";
 
 export type TournamentRanking = {
@@ -33,6 +34,8 @@ export type TournamentDetail = {
 };
 
 export type TournamentMatch = {
+  team_b_id: number;
+  team_a_id: number;
   id: string;
   score_a: number;
   score_b: number;
@@ -49,6 +52,7 @@ export type Team = {
 
 export type InitialState = {
   tournamentDetail: TournamentDetail | null;
+  tournamentAllMatches: TournamentMatch[] | null;
   tournamentMatches: {
     page: number;
     lastPage: number;
@@ -66,6 +70,7 @@ export type InitialState = {
 
 const initialState: InitialState = {
   tournamentDetail: null,
+  tournamentAllMatches: null,
   tournamentMatches: {
     page: 1,
     lastPage: 1,
@@ -161,6 +166,19 @@ const tournamentSlice = createSlice({
         lastPage: 1,
         ranking: null,
       };
+    });
+    //Fetch tournament ALL matches
+    builder.addCase(fetchTournamentAllMatches.pending, (state) => {
+      state.loading = true;
+    });
+    builder.addCase(fetchTournamentAllMatches.fulfilled, (state, action) => {
+      state.loading = false;
+      state.tournamentAllMatches = action.payload;
+    });
+    builder.addCase(fetchTournamentAllMatches.rejected, (state, action) => {
+      state.loading = false;
+      (state.tournamentAllMatches = null),
+        (state.error = action.error.message || "Algo salio mal");
     });
   },
 });

--- a/client/src/redux/slices/tournamentThunk.ts
+++ b/client/src/redux/slices/tournamentThunk.ts
@@ -65,6 +65,14 @@ export const fetchTournamentMatches = createAsyncThunk(
   }
 );
 
+export const fetchTournamentAllMatches = createAsyncThunk(
+  "tournaments/fetchTournamentAllMatches",
+  async ({ id }: { id: string }) => {
+    const result = await api.get(`/tournaments/${id}/allmatches`);
+    return result.data;
+  }
+);
+
 export const fetchTournamentRanking = createAsyncThunk(
   "tournaments/fetchTournamentRanking",
   async ({


### PR DESCRIPTION
Agregué:
En slices: 
-tournaments.ts : addCase fetchTournamentAllMatches...para traer todos los partidos de un torneo, y la propiedad "tournamentAllMatches" en el initial state, donde se cargará un el arrray correspondiente.
-tournamentsThunk.ts : la función fetchTournamentAllMatches
En api/routes/tournaments.ts:
-la ruta GET: "/:id/allmatches", que devuelve todos los partidos de un torneo.
